### PR TITLE
Migrate to Maven Publish Plugin

### DIFF
--- a/analyticskit/build.gradle
+++ b/analyticskit/build.gradle
@@ -26,8 +26,6 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
-		versionCode = 1
-		versionName = rootProject.version ? rootProject.version : "unspecified"
 	}
 	buildTypes {
 		release {
@@ -64,14 +62,14 @@ afterEvaluate {
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'analyticskit'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 			debugAnalyticsKit(MavenPublication) { // Creates a Maven publication called “debugAnalyticsKit”.
 				from components.debug // Applies the component for the debug build variant.
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'analyticskit-debug'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 		}
 	}

--- a/analyticskit/build.gradle
+++ b/analyticskit/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 - 2020 Busy, LLC
+ * Copyright 2016 - 2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
+plugins {
+	id 'com.android.library'
+	id 'kotlin-android'
+}
 
 android {
 	compileSdkVersion rootProject.ext.compileSdkVersion
@@ -53,6 +54,27 @@ dependencies {
 	testImplementation "org.assertj:assertj-core:$rootProject.ext.assertjVersion"
 	testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$rootProject.ext.kotlinVersion"
 	testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$rootProject.ext.kotlinVersion"
+}
+
+afterEvaluate {
+	publishing {
+		publications {
+			releaseAnalyticsKit(MavenPublication) { // Creates a Maven publication called "releaseAnalyticsKit".
+				from components.release // Applies the component for the release build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'analyticskit'
+				version = '0.9.2'
+			}
+			debugAnalyticsKit(MavenPublication) { // Creates a Maven publication called “debugAnalyticsKit”.
+				from components.debug // Applies the component for the debug build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'analyticskit-debug'
+				version = '0.9.2'
+			}
+		}
+	}
 }
 
 task sourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
 	targetSdkVersion = 30
 	buildToolsVersion = "30.0.3"
 	versionCode = 12
-	versionName = "0.7.0"
+	versionName = "$VERSION_NAME"
 
 	// dependency versions
 	assertjVersion = "3.14.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2020-2021 busybusy, Inc.
+ * Copyright 2018, 2020-2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,15 +21,17 @@ buildscript {
 	repositories {
 		google()
 		jcenter()
-		maven { url "https://jitpack.io" }
 		maven { url 'https://maven.fabric.io/public' }
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:4.2.2'
-		classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 		classpath 'com.google.gms:google-services:4.3.8'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10"
 	}
+}
+
+plugins {
+	id 'maven-publish'
 }
 
 allprojects {

--- a/firebase-provider/build.gradle
+++ b/firebase-provider/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2020-2021 busybusy, Inc.
+ * Copyright 2018, 2020-2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
+plugins {
+	id 'com.android.library'
+	id 'kotlin-android'
+}
 
 android {
 	compileSdkVersion rootProject.ext.compileSdkVersion
@@ -63,6 +64,27 @@ dependencies {
 	testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
 	testImplementation 'org.mockito:mockito-core:3.8.0'
 	testImplementation 'org.robolectric:robolectric:4.6.1'
+}
+
+afterEvaluate {
+	publishing {
+		publications {
+			releaseFirebase(MavenPublication) { // Creates a Maven publication called "releaseFirebase".
+				from components.release // Applies the component for the release build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'firebase-provider'
+				version = '0.9.2'
+			}
+			debugFirebase(MavenPublication) { // Creates a Maven publication called “debugFirebase”.
+				from components.debug // Applies the component for the debug build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'firebase-provider-debug'
+				version = '0.9.2'
+			}
+		}
+	}
 }
 
 task sourcesJar(type: Jar) {

--- a/firebase-provider/build.gradle
+++ b/firebase-provider/build.gradle
@@ -26,8 +26,6 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
-		versionCode 1
-		versionName "1.0"
 
 		testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -74,14 +72,14 @@ afterEvaluate {
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'firebase-provider'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 			debugFirebase(MavenPublication) { // Creates a Maven publication called “debugFirebase”.
 				from components.debug // Applies the component for the debug build variant.
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'firebase-provider-debug'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 		}
 	}

--- a/flurry-provider/build.gradle
+++ b/flurry-provider/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2020-2021 busybusy, Inc.
+ * Copyright 2018, 2020-2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
+plugins {
+	id 'com.android.library'
+	id 'kotlin-android'
+}
 
 android {
 	compileSdkVersion rootProject.ext.compileSdkVersion
@@ -63,6 +64,27 @@ dependencies {
 
 	testImplementation "org.powermock:powermock-api-mockito2:2.0.2"
 	testImplementation "org.powermock:powermock-module-junit4:2.0.2"
+}
+
+afterEvaluate {
+	publishing {
+		publications {
+			releaseFlurry(MavenPublication) { // Creates a Maven publication called "releaseFlurry".
+				from components.release // Applies the component for the release build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'flurry-provider'
+				version = '0.9.2'
+			}
+			debugFlurry(MavenPublication) { // Creates a Maven publication called “debugFlurry”.
+				from components.debug // Applies the component for the debug build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'flurry-provider-debug'
+				version = '0.9.2'
+			}
+		}
+	}
 }
 
 task sourcesJar(type: Jar) {

--- a/flurry-provider/build.gradle
+++ b/flurry-provider/build.gradle
@@ -26,8 +26,6 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
-		versionCode 1
-		versionName "0.1.0"
 	}
 	buildTypes {
 		release {
@@ -74,14 +72,14 @@ afterEvaluate {
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'flurry-provider'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 			debugFlurry(MavenPublication) { // Creates a Maven publication called “debugFlurry”.
 				from components.debug // Applies the component for the debug build variant.
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'flurry-provider-debug'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 		}
 	}

--- a/google-analytics-provider/build.gradle
+++ b/google-analytics-provider/build.gradle
@@ -26,8 +26,6 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
-		versionCode 2
-		versionName "0.2.0"
 	}
 	buildTypes {
 		release {
@@ -68,14 +66,14 @@ afterEvaluate {
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'google-analytics-provider'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 			debugGoogle(MavenPublication) { // Creates a Maven publication called “debugGoogle”.
 				from components.debug // Applies the component for the debug build variant.
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'google-analytics-provider-debug'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 		}
 	}

--- a/google-analytics-provider/build.gradle
+++ b/google-analytics-provider/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 - 2018, 2020 busybusy, Inc.
+ * Copyright 2016 - 2018, 2020 - 2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
+plugins {
+	id 'com.android.library'
+	id 'kotlin-android'
+}
 
 android {
 	compileSdkVersion rootProject.ext.compileSdkVersion
@@ -57,6 +58,27 @@ dependencies {
 	testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$rootProject.ext.kotlinVersion"
 	testImplementation "org.assertj:assertj-core:$rootProject.ext.assertjVersion"
 	testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$rootProject.ext.mockitoKotlinVersion"
+}
+
+afterEvaluate {
+	publishing {
+		publications {
+			releaseGoogle(MavenPublication) { // Creates a Maven publication called "releaseGoogle".
+				from components.release // Applies the component for the release build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'google-analytics-provider'
+				version = '0.9.2'
+			}
+			debugGoogle(MavenPublication) { // Creates a Maven publication called “debugGoogle”.
+				from components.debug // Applies the component for the debug build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'google-analytics-provider-debug'
+				version = '0.9.2'
+			}
+		}
+	}
 }
 
 task sourcesJar(type: Jar) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
+
+VERSION_NAME=0.9.2

--- a/graylog-provider/build.gradle
+++ b/graylog-provider/build.gradle
@@ -26,8 +26,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -74,14 +72,14 @@ afterEvaluate {
 
                 groupId = 'com.github.busybusy.AnalyticsKit-Android'
                 artifactId = 'graylog-provider'
-                version = '0.9.2'
+                version = "$VERSION_NAME"
             }
             debugGraylog(MavenPublication) { // Creates a Maven publication called “debugGraylog”.
                 from components.debug // Applies the component for the debug build variant.
 
                 groupId = 'com.github.busybusy.AnalyticsKit-Android'
                 artifactId = 'graylog-provider-debug'
-                version = '0.9.2'
+                version = "$VERSION_NAME"
             }
         }
     }

--- a/graylog-provider/build.gradle
+++ b/graylog-provider/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2020-2021 busybusy, Inc.
+ * Copyright 2018, 2020-2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -63,6 +64,27 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.6.0'
     testImplementation "org.mockito:mockito-core:$rootProject.ext.mockitoVersion"
     testImplementation "org.mockito:mockito-core:3.8.0"
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            releaseGraylog(MavenPublication) { // Creates a Maven publication called "releaseGraylog".
+                from components.release // Applies the component for the release build variant.
+
+                groupId = 'com.github.busybusy.AnalyticsKit-Android'
+                artifactId = 'graylog-provider'
+                version = '0.9.2'
+            }
+            debugGraylog(MavenPublication) { // Creates a Maven publication called “debugGraylog”.
+                from components.debug // Applies the component for the debug build variant.
+
+                groupId = 'com.github.busybusy.AnalyticsKit-Android'
+                artifactId = 'graylog-provider-debug'
+                version = '0.9.2'
+            }
+        }
+    }
 }
 
 task sourcesJar(type: Jar) {

--- a/intercom-provider/build.gradle
+++ b/intercom-provider/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 - 2021 busybusy, Inc.
+ * Copyright 2017 - 2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
+plugins {
+	id 'com.android.library'
+	id 'kotlin-android'
+}
 
 android {
 	compileSdkVersion rootProject.ext.compileSdkVersion
@@ -64,6 +65,27 @@ dependencies {
 
 	testImplementation "org.powermock:powermock-api-mockito2:2.0.2"
 	testImplementation "org.powermock:powermock-module-junit4:2.0.2"
+}
+
+afterEvaluate {
+	publishing {
+		publications {
+			releaseIntercom(MavenPublication) { // Creates a Maven publication called "releaseIntercom".
+				from components.release // Applies the component for the release build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'intercom-provider'
+				version = '0.9.2'
+			}
+			debugIntercom(MavenPublication) { // Creates a Maven publication called “debugIntercom”.
+				from components.debug // Applies the component for the debug build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'intercom-provider-debug'
+				version = '0.9.2'
+			}
+		}
+	}
 }
 
 task sourcesJar(type: Jar) {

--- a/intercom-provider/build.gradle
+++ b/intercom-provider/build.gradle
@@ -26,8 +26,6 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
-		versionCode 1
-		versionName "0.1.0"
 	}
 	buildTypes {
 		release {
@@ -75,14 +73,14 @@ afterEvaluate {
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'intercom-provider'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 			debugIntercom(MavenPublication) { // Creates a Maven publication called “debugIntercom”.
 				from components.debug // Applies the component for the debug build variant.
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'intercom-provider-debug'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 		}
 	}

--- a/kissmetrics-provider/build.gradle
+++ b/kissmetrics-provider/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 busybusy, Inc.
+ * Copyright 2020-2022 busybusy, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -70,6 +70,27 @@ dependencies {
 
     testImplementation "org.powermock:powermock-api-mockito2:2.0.2"
     testImplementation "org.powermock:powermock-module-junit4:2.0.2"
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            releaseKissMetrics(MavenPublication) { // Creates a Maven publication called "releaseKissMetrics".
+                from components.release // Applies the component for the release build variant.
+
+                groupId = 'com.github.busybusy.AnalyticsKit-Android'
+                artifactId = 'kissmetrics-provider'
+                version = '0.9.2'
+            }
+            debugKissMetrics(MavenPublication) { // Creates a Maven publication called “debugKissMetrics”.
+                from components.debug // Applies the component for the debug build variant.
+
+                groupId = 'com.github.busybusy.AnalyticsKit-Android'
+                artifactId = 'kissmetrics-provider-debug'
+                version = '0.9.2'
+            }
+        }
+    }
 }
 
 task sourcesJar(type: Jar) {

--- a/kissmetrics-provider/build.gradle
+++ b/kissmetrics-provider/build.gradle
@@ -26,8 +26,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "0.8.0"
     }
 
     buildTypes {
@@ -80,14 +78,14 @@ afterEvaluate {
 
                 groupId = 'com.github.busybusy.AnalyticsKit-Android'
                 artifactId = 'kissmetrics-provider'
-                version = '0.9.2'
+                version = "$VERSION_NAME"
             }
             debugKissMetrics(MavenPublication) { // Creates a Maven publication called “debugKissMetrics”.
                 from components.debug // Applies the component for the debug build variant.
 
                 groupId = 'com.github.busybusy.AnalyticsKit-Android'
                 artifactId = 'kissmetrics-provider-debug'
-                version = '0.9.2'
+                version = "$VERSION_NAME"
             }
         }
     }

--- a/mixpanel-provider/build.gradle
+++ b/mixpanel-provider/build.gradle
@@ -26,8 +26,6 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
-		versionCode 1
-		versionName "0.1.0"
 	}
 	buildTypes {
 		release {
@@ -73,14 +71,14 @@ afterEvaluate {
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'mixpanel-provider'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 			debugMixpanel(MavenPublication) { // Creates a Maven publication called “debugMixpanel”.
 				from components.debug // Applies the component for the debug build variant.
 
 				groupId = 'com.github.busybusy.AnalyticsKit-Android'
 				artifactId = 'mixpanel-provider-debug'
-				version = '0.9.2'
+				version = "$VERSION_NAME"
 			}
 		}
 	}

--- a/mixpanel-provider/build.gradle
+++ b/mixpanel-provider/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2020-2021 busybusy, Inc
+ * Copyright 2018, 2020-2022 busybusy, Inc
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'kotlin-android'
+plugins {
+	id 'com.android.library'
+	id 'kotlin-android'
+}
 
 android {
 	compileSdkVersion rootProject.ext.compileSdkVersion
@@ -62,6 +63,27 @@ dependencies {
 	testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$rootProject.ext.kotlinVersion"
 	testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$rootProject.ext.kotlinVersion"
 	testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$rootProject.ext.mockitoKotlinVersion"
+}
+
+afterEvaluate {
+	publishing {
+		publications {
+			releaseMixpanel(MavenPublication) { // Creates a Maven publication called "releaseMixpanel".
+				from components.release // Applies the component for the release build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'mixpanel-provider'
+				version = '0.9.2'
+			}
+			debugMixpanel(MavenPublication) { // Creates a Maven publication called “debugMixpanel”.
+				from components.debug // Applies the component for the debug build variant.
+
+				groupId = 'com.github.busybusy.AnalyticsKit-Android'
+				artifactId = 'mixpanel-provider-debug'
+				version = '0.9.2'
+			}
+		}
+	}
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
Migrating to the [Maven Publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html).

This step is a pre-requisite to upgrading the project to Gradle 7.0 and better.