### PR TITLE
Don't throw exception when Intercom provider gets more than 10 attributes

### DIFF
--- a/intercom-provider/build.gradle
+++ b/intercom-provider/build.gradle
@@ -52,9 +52,9 @@ android {
 dependencies {
 	implementation project(path: rootProject.ext.analytics_kit)
 	api "androidx.annotation:annotation:1.2.0"
-	compileOnly 'io.intercom.android:intercom-sdk-base:10.0.1'
+	compileOnly 'io.intercom.android:intercom-sdk-base:10.6.1'
 
-	testImplementation 'io.intercom.android:intercom-sdk-base:10.0.1'
+	testImplementation 'io.intercom.android:intercom-sdk-base:10.6.1'
 	testImplementation "junit:junit:$rootProject.ext.junit_version"
 	testImplementation "org.assertj:assertj-core:$rootProject.ext.assertjVersion"
 	testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$rootProject.ext.kotlinVersion"

--- a/intercom-provider/src/test/kotlin/com/busybusy/intercom_provider/IntercomProviderTest.kt
+++ b/intercom-provider/src/test/kotlin/com/busybusy/intercom_provider/IntercomProviderTest.kt
@@ -126,6 +126,60 @@ class IntercomProviderTest {
 
     @PrepareForTest(Intercom::class)
     @Test
+    fun testQuietMode() {
+        val quietProvider = IntercomProvider(mockedIntercom, { true }, true)
+        val event = AnalyticsEvent("Intercom Event With 11 Attributes")
+                .putAttribute("one", "one")
+                .putAttribute("two", "two")
+                .putAttribute("three", "three")
+                .putAttribute("four", "four")
+                .putAttribute("five", "five")
+                .putAttribute("six", "six")
+                .putAttribute("seven", "seven")
+                .putAttribute("eight", "eight")
+                .putAttribute("nine", "nine")
+                .putAttribute("ten", "ten")
+                .putAttribute("eleven", "eleven")
+
+        assertThat(logEventCalled).isEqualTo(false)
+        quietProvider.sendEvent(event)
+        assertThat(logEventCalled).isEqualTo(true)
+        assertThat(testEventName).isEqualTo("Intercom Event With 11 Attributes")
+        assertThat(testEventPropertiesMap?.keys).hasSize(MAX_METADATA_ATTRIBUTES)
+        assertThat(testEventPropertiesMap?.values).hasSize(MAX_METADATA_ATTRIBUTES)
+    }
+
+    @PrepareForTest(Intercom::class)
+    @Test
+    fun testExceptionThrownWhenNotInQuietMode() {
+        val event = AnalyticsEvent("Intercom Event With 11 Attributes")
+                .putAttribute("one", "one")
+                .putAttribute("two", "two")
+                .putAttribute("three", "three")
+                .putAttribute("four", "four")
+                .putAttribute("five", "five")
+                .putAttribute("six", "six")
+                .putAttribute("seven", "seven")
+                .putAttribute("eight", "eight")
+                .putAttribute("nine", "nine")
+                .putAttribute("ten", "ten")
+                .putAttribute("eleven", "eleven")
+
+        assertThat(logEventCalled).isEqualTo(false)
+        var exception: IllegalStateException? = null
+        try {
+            provider.sendEvent(event)
+        } catch (e: IllegalStateException) {
+            exception = e
+        }
+
+        // Verify Intercom framework is not called
+        assertThat(logEventCalled).isEqualTo(false)
+        assertThat(exception).isNotNull
+    }
+
+    @PrepareForTest(Intercom::class)
+    @Test
     fun testLogContentViewEvent() {
         val event = ContentViewEvent("Test page 7")
         provider.sendEvent(event)
@@ -190,8 +244,8 @@ class IntercomProviderTest {
 
         // Verify Intercom framework is called
         assertThat(logEventCalled).isEqualTo(true)
-        assertThat(testEventPropertiesMap!!.keys).containsExactlyInAnyOrder(provider.DURATION, "some_param", "another_param")
-        assertThat(testEventPropertiesMap!!.values).containsExactlyInAnyOrder(timeString, "yes", "yes again")
+        assertThat(testEventPropertiesMap?.keys).containsExactlyInAnyOrder(provider.DURATION, "some_param", "another_param")
+        assertThat(testEventPropertiesMap?.values).containsExactlyInAnyOrder(timeString, "yes", "yes again")
     }
 
     @PrepareForTest(Intercom::class)
@@ -208,3 +262,5 @@ class IntercomProviderTest {
         assertThat(didThrow).isEqualTo(true)
     }
 }
+
+private const val MAX_METADATA_ATTRIBUTES = 10


### PR DESCRIPTION
This PR adds a "quiet mode" to the Intercom provider that allows consumers of this library to just take the first 10 metadata items from each event without throwing an `IllegalStateException`.

Side note: I reviewed the [Intercom Documentation](https://www.intercom.com/help/en/articles/175-set-up-event-tracking-in-intercom), and they have increased the metadata limit from 5 to 10 since I last went through it.