### PR TITLE
Resolve two Gradle deprecations

### DIFF
--- a/analyticskit/build.gradle
+++ b/analyticskit/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
 	namespace 'com.busybusy.analyticskit_android'
-	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion rootProject.ext.buildToolsVersion
+	compileSdk rootProject.ext.compileSdkVersion
 
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:8.0.1'
+		classpath 'com.android.tools.build:gradle:8.0.2'
 		classpath 'com.google.gms:google-services:4.3.15'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21"
 	}

--- a/firebase-provider/build.gradle
+++ b/firebase-provider/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
 	namespace 'com.busybusy.firebase_provider'
-	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion rootProject.ext.buildToolsVersion
+	compileSdk rootProject.ext.compileSdkVersion
 
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion

--- a/flurry-provider/build.gradle
+++ b/flurry-provider/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
 	namespace 'com.busybusy.flurry_provider'
-	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion rootProject.ext.buildToolsVersion
+	compileSdk rootProject.ext.compileSdkVersion
 
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion

--- a/google-analytics-provider/build.gradle
+++ b/google-analytics-provider/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
 	namespace 'com.busybusy.google_analytics_provider'
-	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion rootProject.ext.buildToolsVersion
+	compileSdk rootProject.ext.compileSdkVersion
 
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion

--- a/graylog-provider/build.gradle
+++ b/graylog-provider/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
     namespace 'com.busybusy.graylog_provider'
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/intercom-provider/build.gradle
+++ b/intercom-provider/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
 	namespace 'com.busybusy.intercom_provider'
-	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion rootProject.ext.buildToolsVersion
+	compileSdk rootProject.ext.compileSdkVersion
 
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion

--- a/kissmetrics-provider/build.gradle
+++ b/kissmetrics-provider/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
     namespace 'com.busybusy.analyticskit.kissmetrics_provider'
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/mixpanel-provider/build.gradle
+++ b/mixpanel-provider/build.gradle
@@ -21,8 +21,7 @@ plugins {
 
 android {
 	namespace 'com.busybusy.mixpanel_provider'
-	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion rootProject.ext.buildToolsVersion
+	compileSdk rootProject.ext.compileSdkVersion
 
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion


### PR DESCRIPTION
This PR addresses two deprecations in the module build files:

- `compileSdkVersion` is replaced by `compileSdk`
- `buildToolsVersion` is replaced by `buildToolsVersion` property

Since the `buildToolsVersion` property is already defined at `rootProject.ext.buildToolsVersion`, we can simply delete the line from each module's build.gradle file.