### PR TITLE
Remove Maven debug publications

### DIFF
--- a/analyticskit/build.gradle
+++ b/analyticskit/build.gradle
@@ -72,13 +72,6 @@ afterEvaluate {
 				artifactId = 'analyticskit'
 				version = "$VERSION_NAME"
 			}
-			debugAnalyticsKit(MavenPublication) { // Creates a Maven publication called “debugAnalyticsKit”.
-				from components.debug // Applies the component for the debug build variant.
-
-				groupId = 'com.github.busybusy.AnalyticsKit-Android'
-				artifactId = 'analyticskit-debug'
-				version = "$VERSION_NAME"
-			}
 		}
 	}
 }

--- a/firebase-provider/build.gradle
+++ b/firebase-provider/build.gradle
@@ -82,13 +82,6 @@ afterEvaluate {
 				artifactId = 'firebase-provider'
 				version = "$VERSION_NAME"
 			}
-			debugFirebase(MavenPublication) { // Creates a Maven publication called “debugFirebase”.
-				from components.debug // Applies the component for the debug build variant.
-
-				groupId = 'com.github.busybusy.AnalyticsKit-Android'
-				artifactId = 'firebase-provider-debug'
-				version = "$VERSION_NAME"
-			}
 		}
 	}
 }

--- a/flurry-provider/build.gradle
+++ b/flurry-provider/build.gradle
@@ -81,13 +81,6 @@ afterEvaluate {
 				artifactId = 'flurry-provider'
 				version = "$VERSION_NAME"
 			}
-			debugFlurry(MavenPublication) { // Creates a Maven publication called “debugFlurry”.
-				from components.debug // Applies the component for the debug build variant.
-
-				groupId = 'com.github.busybusy.AnalyticsKit-Android'
-				artifactId = 'flurry-provider-debug'
-				version = "$VERSION_NAME"
-			}
 		}
 	}
 }

--- a/google-analytics-provider/build.gradle
+++ b/google-analytics-provider/build.gradle
@@ -76,13 +76,6 @@ afterEvaluate {
 				artifactId = 'google-analytics-provider'
 				version = "$VERSION_NAME"
 			}
-			debugGoogle(MavenPublication) { // Creates a Maven publication called “debugGoogle”.
-				from components.debug // Applies the component for the debug build variant.
-
-				groupId = 'com.github.busybusy.AnalyticsKit-Android'
-				artifactId = 'google-analytics-provider-debug'
-				version = "$VERSION_NAME"
-			}
 		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 
-VERSION_NAME=0.10.0
+VERSION_NAME=1.0.0

--- a/graylog-provider/build.gradle
+++ b/graylog-provider/build.gradle
@@ -81,13 +81,6 @@ afterEvaluate {
                 artifactId = 'graylog-provider'
                 version = "$VERSION_NAME"
             }
-            debugGraylog(MavenPublication) { // Creates a Maven publication called “debugGraylog”.
-                from components.debug // Applies the component for the debug build variant.
-
-                groupId = 'com.github.busybusy.AnalyticsKit-Android'
-                artifactId = 'graylog-provider-debug'
-                version = "$VERSION_NAME"
-            }
         }
     }
 }

--- a/intercom-provider/build.gradle
+++ b/intercom-provider/build.gradle
@@ -81,13 +81,6 @@ afterEvaluate {
 				artifactId = 'intercom-provider'
 				version = "$VERSION_NAME"
 			}
-			debugIntercom(MavenPublication) { // Creates a Maven publication called “debugIntercom”.
-				from components.debug // Applies the component for the debug build variant.
-
-				groupId = 'com.github.busybusy.AnalyticsKit-Android'
-				artifactId = 'intercom-provider-debug'
-				version = "$VERSION_NAME"
-			}
 		}
 	}
 }

--- a/kissmetrics-provider/build.gradle
+++ b/kissmetrics-provider/build.gradle
@@ -87,13 +87,6 @@ afterEvaluate {
                 artifactId = 'kissmetrics-provider'
                 version = "$VERSION_NAME"
             }
-            debugKissMetrics(MavenPublication) { // Creates a Maven publication called “debugKissMetrics”.
-                from components.debug // Applies the component for the debug build variant.
-
-                groupId = 'com.github.busybusy.AnalyticsKit-Android'
-                artifactId = 'kissmetrics-provider-debug'
-                version = "$VERSION_NAME"
-            }
         }
     }
 }

--- a/mixpanel-provider/build.gradle
+++ b/mixpanel-provider/build.gradle
@@ -81,13 +81,6 @@ afterEvaluate {
 				artifactId = 'mixpanel-provider'
 				version = "$VERSION_NAME"
 			}
-			debugMixpanel(MavenPublication) { // Creates a Maven publication called “debugMixpanel”.
-				from components.debug // Applies the component for the debug build variant.
-
-				groupId = 'com.github.busybusy.AnalyticsKit-Android'
-				artifactId = 'mixpanel-provider-debug'
-				version = "$VERSION_NAME"
-			}
 		}
 	}
 }


### PR DESCRIPTION
I've been thinking about this for a while and I don't see any reason for the debug artifacts to exist. This change removes those debug publications. 

In preparation for the next release, I have rolled the version number in gradle.properties.